### PR TITLE
Fixed typographical error, changed aquainted to acquainted in README.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -4,7 +4,7 @@
 of application configuration. 
 
 This utlity is developed keeping developer's convenience in mind. Configurations in ruby or RoR are mostly 
-done in YAML format. Other language programmers are well aquainted with XML format and this utility helps them 
+done in YAML format. Other language programmers are well acquainted with XML format and this utility helps them 
 to easily use without learning new configuration format. 
 
 It mainly has three features 


### PR DESCRIPTION
@edewcode, I've corrected a typographical error in the documentation of the [rubyconfigr](https://github.com/edewcode/rubyconfigr) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
